### PR TITLE
OD12-329 Automate year opening entries

### DIFF
--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -268,6 +268,7 @@ def remove_account_moves_from_special_periods(cr):
         USING account_period p, account_journal j
         WHERE l.period_id=p.id AND l.journal_id=j.id
         AND p.special AND j.centralisation
+        AND l.move_id <> 21856
     """)
 
     openupgrade.logged_query(cr, """
@@ -279,6 +280,7 @@ def remove_account_moves_from_special_periods(cr):
             FROM account_move_line
             WHERE name = 'Year opening entry'
         )
+        AND m.id <> 21856
     """)
 
 


### PR DESCRIPTION
For each fiscal year and each entity, take the balance of lines on the centralization account in each traditional opening entry in Odoo 8.

Keep the lines on the centralization account and add the balance line on account 9999.

Create account 9999 in all entities (if not existing).

Move the entries out of the special opening period into the normal period.
