### PR TITLE
OD12-329 Automate year opening entries

### DIFF
--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -690,6 +690,7 @@ def update_year_opening_entries(env):
                 'user_type_id': unaffected_earnings_xml.id,
                 'company_id': company.id, })
         openupgrade.logged_query(
+            env.cr,
             """
             UPDATE account_move_line aml
             SET account_id = %s

--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -268,6 +268,7 @@ def remove_account_moves_from_special_periods(cr):
         USING account_period p, account_journal j
         WHERE l.period_id=p.id AND l.journal_id=j.id
         AND p.special AND j.centralisation
+        AND l.move_id <> 21856
     """)
 
     openupgrade.logged_query(cr, """
@@ -279,6 +280,7 @@ def remove_account_moves_from_special_periods(cr):
             FROM account_move_line
             WHERE name = 'Year opening entry'
         )
+        AND m.id <> 21856
     """)
 
 

--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -281,7 +281,11 @@ def remove_account_moves_from_special_periods(cr):
             WHERE name = 'Year opening entry'
         )
         AND m.id <> 21856
+        RETURNING m.id, m.name
     """)
+    for row in cr.fetchall():
+        logger.info("Deleted opening balance account.move#%s (%s)",
+                    row[0], row[1])
 
 
 def install_account_tax_python(cr):


### PR DESCRIPTION
Continues https://github.com/VanMoof/OpenUpgrade/pull/1

-----

For each fiscal year and each entity, take the balance of lines on the centralization account in each traditional opening entry in Odoo 8.

Keep the lines on the centralization account and add the balance line on account 9999. Create account 9999 in all entities (if not existing).

Add check that the modified moves have total balance = 0.

Move with id=21856 ("Opening Balance 2016 from SAP") has no centralization lines for it, so it will be fixed separately.