### PR TITLE
OD12-343 migrate bic numbers

### DIFF
--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -370,6 +370,38 @@ def set_date_maturity(env):
     )
 
 
+def migrate_bic_numbers(env):
+    """ BIC numbers migrated in supplier bank details """
+    # if no bank exists with a matching BIC, automatically create a new bank, with the new BIC;
+    # if the bank account details do not specify the bank name, use the BIC as bank name.
+    openupgrade.logged_query(
+        env.cr, """
+        INSERT INTO res_bank(name, bic)
+        SELECT CASE WHEN bank_name IS NOT NULL THEN bank_name ELSE bank_bic END, bank_bic
+        FROM res_partner_bank
+        WHERE bank IS NULL AND bank_bic IS NOT NULL AND bank_bic NOT IN (
+            SELECT bic
+            FROM res_bank
+            WHERE bic IS NOT NULL
+        )
+        GROUP BY bank_name, bank_bic
+        """
+    )
+    # if a bank object with a matching BIC exists, link the bank account to that bank
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE res_partner_bank rpb
+        SET bank = subquery.id
+        FROM (
+            SELECT rb.id, rb.bic
+            FROM res_bank rb
+            WHERE rb.bic IS NOT NULL
+        ) AS subquery
+        WHERE rpb.bank IS NULL AND rpb.bank_bic = subquery.bic
+        """
+    )
+
+
 def fast_create(env, settings):
     for setting in settings:
         (table_name, field_name, sql_type, sql_request) = setting
@@ -421,6 +453,7 @@ def migrate(env, version):
     merge_supplier_invoice_refs(env)
     openupgrade.rename_fields(env, field_renames)
     set_date_maturity(env)
+    migrate_bic_numbers(env)
 
     # Fast Create new fields
     fast_create(env, FAST_CREATIONS)


### PR DESCRIPTION
When migrating bank accounts that are not linked to an existing bank, but do include a Bank Name and/or Bank Identifier Code (BIC):

- if a bank object with a matching BIC exists, link the bank account to that bank;

- if no bank exists with a matching BIC, automatically create a new bank, with the new BIC;

- -  if the bank account details do not specify the bank name, use the BIC as bank name.


NOTE There are a few inconsistencies to be fixed manually: some bank accounts have BIC different than the linked bank. To find them:

```SQL
	select rpb.bank_bic, rb.bic, rb.name, rb.id
	from res_partner_bank rpb
	  join res_bank rb on rpb.bank = rb.id
	where rpb.bank_bic <> rb.bic
```
